### PR TITLE
👩‍💻 Improve document import and chat functionality

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Controllers/DocumentImportController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/DocumentImportController.cs
@@ -176,8 +176,8 @@ public class DocumentImportController : ControllerBase
 
         // Split the document into lines of text and then combine them into paragraphs.
         // NOTE that this is only one of the strategies to chunk documents. Feel free to experiment with other strategies.
-        var lines = TextChunker.SplitPlainTextLines(content, 2048 /*this._options.DocumentLineSplitMaxTokens*/);
-        var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, 2048 /*this._options.DocumentParagraphSplitMaxLines*/);
+        var lines = TextChunker.SplitPlainTextLines(content, 128 /*this._options.DocumentLineSplitMaxTokens*/);
+        var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, 512 /*this._options.DocumentParagraphSplitMaxLines*/);
 
         foreach (var paragraph in paragraphs)
         {

--- a/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
@@ -269,7 +269,7 @@ internal static class SemanticKernelExtensions
     internal static KernelConfig AddImageGenerationBackend(this KernelConfig kernelConfig)
     {
         kernelConfig.AddImageGenerationService(_ =>
-            new HuggingFaceTextToImage("", model: "stabilityai/stable-diffusion-2-1"));
+            new HuggingFaceTextToImage("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", model: "stabilityai/stable-diffusion-2-1"));
 
         return kernelConfig;
     }

--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -649,7 +649,7 @@ public class ChatSkill
 
             Console.WriteLine("***reading***");
 
-            var prompt = $"Review the [MESSAGES] and determine which function to run. If unsure, use 'DoChat'.\n[BANNED FUNCTIONS]AcquireExternalInformation, Chat[END BANNED FUNCTIONS]\n[MESSAGES]\nUser Input:{context.Variables.Input}\n{userIntent}\n[END MESSAGES]\n";
+            var prompt = $"Review the [MESSAGES] and determine which function to run. If unsure, use 'DoChat'.\n[BANNED FUNCTIONS]AcquireExternalInformation, Chat, ExtractUserMemories[END BANNED FUNCTIONS]\n[MESSAGES]\nUser Input:{context.Variables.Input}\n{userIntent}\n[END MESSAGES]\n";
             Console.WriteLine(prompt);
             var plan = await planner.CreatePlanAsync(prompt);
 

--- a/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/JiraSkill/openapi.json
+++ b/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/JiraSkill/openapi.json
@@ -15,12 +15,8 @@
   },
   "host": "yourhost.yourdomain.com",
   "basePath": "/rest/api/latest/",
-  "schemes": [
-    "https"
-  ],
-  "produces": [
-    "application/json"
-  ],
+  "schemes": ["https"],
+  "produces": ["application/json"],
   "paths": {
     "/issue/{issueKey}": {
       "get": {
@@ -43,6 +39,99 @@
             "description": "OK",
             "schema": {
               "$ref": "#/definitions/FullIssue"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "advanced"
+      }
+    },
+    "/search": {
+      "get": {
+        "summary": "Search for issues using JQL (GET)",
+        "description": "Searches for issues using JQL.\n\nIf the JQL query expression is too large to be encoded as a query parameter, use the POST version of this resource.\n\nThis operation can be accessed anonymously.",
+        "operationId": "SearchForIssuesUsingJQL",
+        "parameters": [
+          {
+            "name": "jql",
+            "in": "query",
+            "description": "The JQL that defines the search. Note:\n\nIf no JQL expression is provided, all issues are returned.\nusername and userkey cannot be used as search terms due to privacy reasons. Use accountId instead.\nIf a user has hidden their email address in their user profile, partial matches of the email address will not find the user. An exact match is required.",
+            "required": false,
+            "x-ms-summary": "JQL",
+            "type": "string",
+            "x-ms-test-value": ""
+          },
+          {
+            "name": "startAt",
+            "in": "query",
+            "description": "The index of the first item to return in a page of results (page offset).\n\nDefault: 0\nFormat: int32",
+            "required": false,
+            "x-ms-summary": "Start At",
+            "type": "integer",
+            "format": "int32",
+            "x-ms-test-value": 0
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "description": "The maximum number of items to return per page. To manage page size, Jira may return fewer items per page where a large number of fields are requested. The greatest number of items returned per page is achieved when requesting id or key only.\n\nDefault: 50\nFormat: int32",
+            "required": false,
+            "x-ms-summary": "Max Results",
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "validateQuery",
+            "in": "query",
+            "description": "Determines how to validate the JQL query and treat the validation results. Supported values are:\n\nstrict Returns a 400 response code if any errors are found, along with a list of all errors (and warnings).\nwarn Returns all errors as warnings.\nnone No validation is performed.\ntrue Deprecated A legacy synonym for strict.\nfalse Deprecated A legacy synonym for warn.\nNote: If the JQL is not correctly formed a 400 response code is returned, regardless of the validateQuery value.\n\nDefault: strict\nValid values: strict, warn, none, true, false",
+            "required": false,
+            "x-ms-summary": "Validate Query",
+            "type": "string",
+            "enum": ["strict", "warn", "none", "true", "false"],
+            "x-ms-test-value": "strict"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "A list of fields to return for each issue, use it to retrieve a subset of fields. This parameter accepts a comma-separated list. Expand options include:\n\n*all Returns all fields.\n*navigable Returns navigable fields.\nAny issue field, prefixed with a minus to exclude.\nExamples:\n\nsummary,comment Returns only the summary and comments fields.\n-description Returns all navigable (default) fields except description.\n*all,-comment Returns all fields except comments.\nThis parameter may be specified multiple times. For example, fields=field1,field2&fields=field3.\n\nNote: All navigable fields are returned by default. This differs from GET issue where the default is all fields.",
+            "required": false,
+            "x-ms-summary": "Fields",
+            "type": "string",
+            "x-ms-test-value": "summary,comment"
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "description": "Use expand to include additional information about issues in the response. This parameter accepts a comma-separated list. Expand options include:\n\nrenderedFields Returns field values rendered in HTML format.\nnames Returns the display name of each field.\nschema Returns the schema describing a field type.\ntransitions Returns all possible transitions for the issue.\noperations Returns all possible operations for the issue.\neditmeta Returns information about how each field can be edited.\nchangelog Returns a list of recent updates to an issue, sorted by date, starting from the most recent.\nversionedRepresentations Instead of fields, returns versionedRepresentations a JSON array containing each version of a field's value, with the highest numbered item representing the most recent version.\nproperties",
+            "required": false,
+            "x-ms-summary": "Expand",
+            "type": "string",
+            "x-ms-test-value": "renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations,properties"
+          },
+          {
+            "name": "properties",
+            "in": "query",
+            "description": "A list of issue properties to return for each issue. This parameter accepts a comma-separated list. Allowed values:\n\n*all Returns all issue properties.\n*none Returns no issue properties.\nAny issue property key, prefixed with a minus to exclude. For example, properties=-prop1,-prop2.\nThis parameter may be specified multiple times. For example, properties=prop1,prop2&properties=prop3.\n\nNote: This parameter cannot be used with the fields parameter.",
+            "required": false,
+            "x-ms-summary": "Properties",
+            "type": "string",
+            "x-ms-test-value": "all"
+          },
+          {
+            "name": "fieldsByKeys",
+            "in": "query",
+            "description": "Reference fields by their key (rather than ID).",
+            "required": false,
+            "x-ms-summary": "Fields By Keys",
+            "type": "boolean",
+            "x-ms-test-value": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SearchResults"
             }
           }
         },
@@ -884,22 +973,15 @@
       }
     },
     "CreateIssueRequest": {
-      "required": [
-        "fields"
-      ],
+      "required": ["fields"],
       "type": "object",
       "properties": {
         "fields": {
-          "required": [
-            "summary",
-            "issuetype"
-          ],
+          "required": ["summary", "issuetype"],
           "type": "object",
           "properties": {
             "issuetype": {
-              "required": [
-                "id"
-              ],
+              "required": ["id"],
               "type": "object",
               "properties": {
                 "id": {
@@ -1158,9 +1240,7 @@
       }
     },
     "Comment": {
-      "required": [
-        "body"
-      ],
+      "required": ["body"],
       "type": "object",
       "properties": {
         "body": {
@@ -1194,6 +1274,25 @@
           "x-ms-summary": "Created Date-Time",
           "description": "yyyy-MM-ddTHH:mm:ss.fffZ",
           "x-ms-visibility": "advanced"
+        }
+      }
+    },
+
+    "SearchResults": {
+      "type": "object",
+      "properties": {
+        "expand": {
+          "type": "string",
+          "x-ms-summary": "Expand",
+          "description": "Expand options that include additional search result details in the response."
+        },
+        "issues": {
+          "type": "array",
+          "x-ms-summary": "Issues",
+          "description": "List of issues found in the search.",
+          "items": {
+            "$ref": "#/definitions/FullIssue"
+          }
         }
       }
     }


### PR DESCRIPTION
🔎 Add search issues operation to Jira skill

This commit makes several improvements to the copilot-chat-app, including:

- Reducing the size of the text chunks for document splitting, to avoid exceeding the token limit of the semantic kernel.
- Banning the ExtractUserMemories function from the chat skill, to prevent privacy issues.
- Updating the HuggingFaceTextToImage service to use a valid API token.
- Adding a new Jira skill that allows searching for issues using JQL.

The Jira skill can accept various query parameters to customize the search results, such as fields, expand, properties, and fieldsByKeys. It returns a list of issues that match the search criteria, along with some metadata. The openapi.json file is updated to include the new operation and its schemas. The operation is marked as advanced to indicate that it requires some knowledge of JQL and Jira fields.
